### PR TITLE
update to pyethereum v2.3.0

### DIFF
--- a/Examples/RPS_v1_new.py
+++ b/Examples/RPS_v1_new.py
@@ -1,6 +1,6 @@
 import serpent
-from pyethereum import tester, utils, abi
-
+from ethereum import utils, abi
+from ethereum.tools import tester
 serpent_code = '''
 data player[2](address, choice)
 data num_players
@@ -69,8 +69,8 @@ def balance_check():
 
 '''
 
-s = tester.state()
-c = s.abi_contract(serpent_code)
+s = tester.Chain()
+c = s.contract(serpent_code,language='serpent')
 
 o = c.add_player(2,value=1000,sender=tester.k0)
 print("Player 1 Added: {}").format(o)

--- a/Examples/RPS_v1_old.py
+++ b/Examples/RPS_v1_old.py
@@ -1,5 +1,6 @@
 import serpent
-from pyethereum import tester, utils, abi
+from ethereum import utils, abi
+from ethereum.tools import tester
 
 serpent_code = '''
 data winnings_table[3][3]
@@ -80,8 +81,8 @@ def balance_check():
 	log(self.storage["player2"].balance)
 '''
 
-s = tester.state()
-c = s.abi_contract(serpent_code)
+s = tester.Chain()
+c = s.contract(serpent_code,language='serpent')
 
 o = c.add_player(value=1000,sender=tester.k0)
 print("Player 1 Added: {}").format(o)

--- a/Examples/RPS_v2_new.py
+++ b/Examples/RPS_v2_new.py
@@ -1,5 +1,6 @@
 import serpent
-from pyethereum import tester, utils, abi
+from ethereum import utils, abi
+from ethereum.tools import tester
 from sha3 import sha3_256
 import sys
 import struct
@@ -137,8 +138,8 @@ def test_callstack():
 	return(1)
 '''
 
-s = tester.state()
-c = s.abi_contract(serpent_code)
+s = tester.Chain()
+c = s.contract(serpent_code,language='serpent')
 
 print("Output of 1 designated success for player 1.")
 print("Output of 2 designated success for player 2.")

--- a/Examples/RPS_v2_old.py
+++ b/Examples/RPS_v2_old.py
@@ -1,5 +1,6 @@
 import serpent
-from pyethereum import tester, utils, abi
+from ethereum import utils, abi
+from ethereum.tools import tester
 from sha3 import sha3_256
 import sys
 import struct
@@ -154,8 +155,8 @@ def test_callstack():
 	return(1)
 '''
 
-s = tester.state()
-c = s.abi_contract(serpent_code)
+s = tester.Chain()
+c = s.contract(serpent_code,language='serpent')
 
 print("Output of 1 designated success for player 1.")
 print("Output of 2 designated success for player 2.")

--- a/Examples/easy_bank.py
+++ b/Examples/easy_bank.py
@@ -1,6 +1,6 @@
 import serpent
-from pyethereum import tester, utils, abi
-
+from ethereum import utils, abi
+from ethereum.tools import tester
 serpent_code = '''
 def init():
 	#Initialiaze the contract creator with 10000 fake dollars
@@ -24,9 +24,9 @@ public_k0 = utils.privtoaddr(tester.k0)
 public_k1 = utils.privtoaddr(tester.k1)
 
 #Generate state and add contract to block chain
-s = tester.state()
+s = tester.Chain()
 print("Tester state created")
-c = s.abi_contract(serpent_code)
+c = s.contract(serpent_code,language='serpent')
 print("Code added to block chain")
 
 #Test Contract

--- a/Examples/mutual_credit_system.py
+++ b/Examples/mutual_credit_system.py
@@ -1,5 +1,6 @@
 import serpent
-from pyethereum import tester, utils, abi
+from ethereum import utils, abi
+from ethereum.tools import tester
 
 #A mutual credit system will zero out when all debts are paid.
 
@@ -24,8 +25,8 @@ def balance(addr):
 public_k0 = utils.privtoaddr(tester.k0)
 public_k1 = utils.privtoaddr(tester.k1)
 
-s = tester.state()
-c = s.abi_contract(serpent_code)
+s = tester.Chain()
+c = s.contract(serpent_code,language='serpent')
 
 o = c.balance(public_k0)
 print("tester.k0's current balance is " + str(o))

--- a/Examples/namecoin.py
+++ b/Examples/namecoin.py
@@ -1,5 +1,6 @@
 import serpent
-from pyethereum import tester, utils, abi
+from ethereum import utils, abi
+from ethereum.tools import tester
 
 serpent_code = '''
 def register(key, value):
@@ -22,9 +23,9 @@ def get(key):
 public_k1 = utils.privtoaddr(tester.k1)
 
 #Generate state and add contract to block chain
-s = tester.state()
+s = tester.Chain()
 print("Tester state created")
-c = s.abi_contract(serpent_code)
+c = s.contract(serpent_code,language='serpent')
 print("Code added to block chain")
 
 #Test contract

--- a/Examples/new_bank_contract.py
+++ b/Examples/new_bank_contract.py
@@ -1,5 +1,6 @@
 import serpent
-from pyethereum import tester, utils, abi
+from ethereum import utils, abi
+from ethereum.tools import tester
 
 serpent_code = '''
 #Deposit
@@ -36,8 +37,8 @@ def balance():
 
 public_k1 = utils.privtoaddr(tester.k1)
 
-s = tester.state()
-c = s.abi_contract(serpent_code)
+s = tester.Chain()
+c = s.contract(serpent_code,language='serpent')
 
 o = c.deposit(value=1000, sender=tester.k0)
 if o == 1:

--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ The corresponding makefile for the two `.tex`files is also in [Guides/](Guides/)
 The lab uses [pyethereum](https://github.com/ethereum/pyethereum). Detailed download instructions can be found on pyethereum's 
 github or you can follow instructions in [Guides/serpent_tutorial.tex](Guides/serpent_tutorial.tex) to install our preconfigured VM-image. ([download .zip](https://drive.google.com/file/d/0BzlG8wGYwTrGODVPZmFUV1UyYlk/view?usp=sharing))
 
+We have designed open course materials and lab designs for smart contract programming on [Ethereumlab: Towards Safe Smart Contracts](http://mc2-umd.github.io/ethereumlab/)
+
 Authors: Kevin Delmolino, Mitchell Arnett, Ahmed Kosba, Andrew Miller, Elaine Shi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ The corresponding makefile for the two `.tex`files is also in [Guides/](Guides/)
 The lab uses [pyethereum](https://github.com/ethereum/pyethereum). Detailed download instructions can be found on pyethereum's 
 github or you can follow instructions in [Guides/serpent_tutorial.tex](Guides/serpent_tutorial.tex) to install our preconfigured VM-image. ([download .zip](https://drive.google.com/file/d/0BzlG8wGYwTrGODVPZmFUV1UyYlk/view?usp=sharing))
 
-We have designed open course materials and lab designs for smart contract programming on [Ethereumlab: Towards Safe Smart Contracts](http://mc2-umd.github.io/ethereumlab/)
+Open course materials and lab designs for smart contract programming are in [Ethereumlab: Towards Safe Smart Contracts](http://mc2-umd.github.io/ethereumlab/)
 
 Authors: Kevin Delmolino, Mitchell Arnett, Ahmed Kosba, Andrew Miller, Elaine Shi


### PR DESCRIPTION
According to [Using pyethereum.tester](https://github.com/ethereum/pyethereum/wiki/Using-pyethereum.tester), the `.py` files are  modified to be compatible with the new version of `pyethereum`lab.
A url contains some course material are added in **README** file in the root directory.